### PR TITLE
closes #92; Compatibility with remove-invitation-links-button module

### DIFF
--- a/src/styles/tidy-ui_game-settings.css
+++ b/src/styles/tidy-ui_game-settings.css
@@ -38,7 +38,10 @@
   margin-top: 1rem;
 }
 
-#settings button[data-action="logout"],
+#settings button[data-action="invitations"] {
+  margin-bottom: 1rem;
+}
+
 #settings button[data-action="players"] {
   margin-top: 1rem;
 }


### PR DESCRIPTION
Fix gap between category name and Log Out button, when used in combination with remove-invitation-links-button module.