### PR TITLE
Fix for misaligned checks in v11

### DIFF
--- a/src/styles/tidy-ui_game-settings.css
+++ b/src/styles/tidy-ui_game-settings.css
@@ -116,9 +116,7 @@
   position: absolute;
   width: 16px;
   height: 16px;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translate(5%, 5%);
 }
 
 #module-management .package-list {


### PR DESCRIPTION
Before fix: 
![image](https://github.com/sdenec/tidy-ui_game-settings/assets/73143074/08755bf5-0725-423d-905e-c9edfcae0a5b)

After fix: 
![image](https://github.com/sdenec/tidy-ui_game-settings/assets/73143074/867daecb-4634-4ccb-8fe5-9da33e4e66f1)
